### PR TITLE
Adjust staff overlay

### DIFF
--- a/assets/scss/site/compatibility/page-builder/beaverbuilder/_post-grid.scss
+++ b/assets/scss/site/compatibility/page-builder/beaverbuilder/_post-grid.scss
@@ -28,7 +28,7 @@
 					position: absolute;
 					width: 100%;
 					height: 100%;
-					background: rgba(66, 66, 66, 0.4);
+					background: rgba(66, 66, 66, 0.2);
 					left: 0;
 					top: 0;
 					border-radius: 0;


### PR DESCRIPTION
This adjusts staff overlay opacity from 40% down to 20% so the staff photos are more clearly visible while allowing the white text to retain enough contrast. 