### PR TITLE
Fix hero image right margin

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -86,6 +86,10 @@ div.fl-row.hero {
 	
 	@include media-breakpoint-down(sm) {
 		
+		.fl-module-content {
+			margin-right: 0;
+		}
+
 		.fl-col:first-child {
 			.fl-col-content {
 				padding-bottom: 0;


### PR DESCRIPTION
Beaver Builder is adding 1rem of right margin to the hero images on mobile even though the value is unset in the builder. Manually overriding to 0 in BB resolves this. 

This commit targets the element in the small breakpoint to set the margin-right to 0 at a global scale to override what Beaver Builder is generating. 